### PR TITLE
basics & fundamentos updates

### DIFF
--- a/03-cartography/resources/basics.md
+++ b/03-cartography/resources/basics.md
@@ -64,6 +64,12 @@ The following two styles are based on the same principle, but instead of using s
 
 Choropleth maps are one of the most well known thematic maps. Especially suited to mapping densities, these maps are a great way to visualize intensity, and also to explain geographic similarities and differences.
 
+It is important to use a normalized (rate) attribute in a choropleth instead of a raw count. Counts show magnitude instead of concentration. In the dataset below, both Nigeria (pop2005 = 141,356,083 people) and Russia (pop2005 = 143,953,092 people) have ~140 million people. If we make a choropleth using the pop2005 attribute, Russia and Nigeria are the same color because they are included in the same bucket. This is misleading if what we're really trying to map is how crowded or population-dense those countries are, since Russia covers a much bigger area. To see density we need to factor out area size, like in the SQL example below. If you want to work with raw counts instead Bubble maps are a better option.
+
+It's also important to consider [quantification](https://carto.com/academy/courses/intermediate-design/which-kind-of-map-should-i-make#quantification), since that's how your data is bucketed into choropleth bins. Each method can make your map look dramatically different.
+
+*Tip*: Prioritize legibility: Make sure to choose a color ramp that contrasts with your basemap colors enough to be easily readable.
+
 ### Style countries based upon normalized population
 
 * Data Source: `world_borders` from DATA LIBRARY
@@ -207,6 +213,10 @@ FROM
 ```
 
 We can see that CARTO will read this as all markers should have a width value of 3. If the zoom equals 4, the marker width value should be 6. If the zoom equals 5, the marker width value should be 12. Finally, if the zoom is larger than 5, the marker width value should be 16. This means that as we zoom in, the markers become bigger. [Go ahead and play around with this](https://team.carto.com/u/ramirocartodb/builder/33e2696c-badf-11e6-80bd-0ee66e2c9693/embed) to see what kinds of visualizations you can make based on zoom.
+
+*Note*: When nested conditional styles apply to more than one case, the bottom-most styles take precedence.
+
+*Tip*: If you're working with choropleth polygons, check the legibility of the smallest polygon at each zoom level to judge how to adjust your styles.
 
 ## Torque
 

--- a/03-cartography/resources/cartocss.md
+++ b/03-cartography/resources/cartocss.md
@@ -188,6 +188,8 @@ For instance, all the lines within this code are the same:
 ![yellow](exercises/img/yellow.png)
 <br>
 
+*Note*: You can ramp transparency with color inside Turbo CARTO by using rgba instead of hex colors.
+
 *Note*: Using hsl [(hue, saturation, lightness)](http://mothereffinghsl.com/) color values are often easier than rgb()values. CARTO also includes several color functions [borrowed from Less, a CSS pre-processor](http://lesscss.org/#-color-functions):
 
 ```css
@@ -228,9 +230,11 @@ Each of above examples uses color variables, literal colors, or is the result of
 ![lighten](exercises/img/lighten.png)
 <br>
 
+*Note*: Polygon-gamma is the amount of anti-aliasing applied to your polygon's edges. Anti-aliasing reduces the jagged appearance of polygon edges, so that they appear more smooth. Values can range from 0 (no anti-aliasing, sharp edges) to 1 (fully anti-aliased).
+
 ## Composite operations
 
-Composite operations style the way colors of overlapping geometries interact with each other. Similar to blend operations in Photoshop, these composite operations style the blend modes on your map. The main reason to use composite operations is to fine-tune how much some features in your map stand out compared to others. They are a great way to control your maps legibility.
+Composite operations style the way colors of overlapping geometries interact with each other. Similar to blend operations in Photoshop, these composite operations style the blend modes on your map's data layers (not including the basemap). The main reason to use composite operations is to fine-tune how much some features in your map stand out compared to others. They are a great way to control your maps legibility.
 
 Composite operations are blending modes for your map layers. They fall into two main categories: [color](https://carto.com/docs/carto-engine/cartocss/composite-operations/#color-blending-values) and [alpha](https://carto.com/docs/carto-engine/cartocss/composite-operations/#alpha-blending-values), and can be applied to all non-basemap elements in your CARTO map by adding the comp-op value to your CartoCSS code.
 
@@ -283,5 +287,24 @@ When applying CartoCSS syntax, it helps to understand how values are applied to 
 * Any layers that appear above the source are unaffected by the applied style and are rendered normally
 * Typically, you apply CartoCSS properties to different layers on a map. You can add multiple styles and values for each layer
 * Alternatively, you can apply CartoCSS by nesting categories and values. Categories contain multiple values listed under the same, single category using brackets `{ }`. This enables you visualize all of the styling elements applied to the overall map or to individual symbolizers, and avoid adding any redundant or unnecessary parameters. This is the suggested method if you are applying styles to a multi-scale map.
+* Check your styles at each zoom level and modify as needed to maintain proper information hierarchy.
 
-*Note*: Be mindful when applying styles to a map with multiple layers. Instead of applying an overall style to each map layer, apply the style to one layer on the map using this nested structure. For example, suppose you have a map with four layers, you can define zoom dependent styling as a nested value in one map layer. You do not have to go through each layer of the map to apply a zoom style. Using the nested structure allows you to apply all of the styling inside the brackets `{ }`. This is a more efficient method of applying overall map styling.
+```css
+#layer {
+  marker-width: 7;
+  marker-fill: #FFB927;
+  marker-fill-opacity: 0.9;
+  marker-allow-overlap: true;
+  marker-line-width: 1;
+  marker-line-color: #FFF;
+  marker-line-opacity: 1;
+  marker-comp-op: multiply;
+
+  [zoom = 6]{ marker-width: 10; }
+  [zoom >= 7]{ marker-width: 13; }
+  [zoom >= 10]{ marker-width: 18; }
+}
+
+*Note*: Be mindful when applying styles to a map with multiple layers. Instead of applying an overall style to each map layer, apply the style to one layer on the map using this nested structure. For example, suppose you have a map with four layers, you can define zoom dependent styling as a nested value in one map layer. You do not have to go through each layer of the map to apply a zoom style. Using the nested structure allows you to apply all of the styling inside the brackets `{ }`. This is a more efficient method of applying overall map styling. 
+
+When nested conditional styles apply to more than one case, the bottom-most styles take precedence. If the ```[zoom >= 10]``` code block above was listed above the ```[zoom >= 7]``` block, then markers at zoom 11 would be 13px.


### PR DESCRIPTION
Hi @jsanz @michellechandra @ramiroaznar @ernesmb @oriolbx - look ok?

* I also added comment to [Design Better Maps with CARTO](https://docs.google.com/presentation/d/1LbBIFPEWki58F2yRdbESTKGgm_sjnZRf9VV4odLGPlM/edit#slide=id.g1344866868_0_46) slide 8 re: changing projection. Didn't add elsewhere b/c it requires plain background instead of basemap, so not optimal as best practice I think.

* I left off Raul's tool to see bin breaks w/Turbo Carto b/c I hear we're not exposing it to clients, but if you want to use it during workshops it's [here](http://bl.ocks.org/rochoa/raw/4e67ec932e8bb6b17831e0f4a2e0e55d/).
> instructions: 
https://docs.google.com/document/d/1wEy0jV3J-i6BY2zgCS3bXLLaJODBHMEZjM6Dyd3ggI4/edit

* I did not include [this map](https://gist.github.com/ztephm/2914ca06a9dce089d83aa120202df337) - it was fine for internal purposes but I think not great for introduction to cartography. The purpose was to illustrate what to do in a "problem" situation, like when you need to make elements stand out while using transparency. I reviewed w/Mamata & we solved things like balancing unreadable clusters of tiny polys:

  ![b77a4d56-d1cf-11e6-9957-b2b002c93b41_360](https://cloud.githubusercontent.com/assets/1779444/21659466/d1ea48d4-d298-11e6-8e6a-0bfb3313b945.png)

  ...against areas that look like they combine into one large poly:
![00eb9fe0-d1c5-11e6-8c34-72287c8807ef_360](https://cloud.githubusercontent.com/assets/1779444/21659494/fe25efac-d298-11e6-9a08-02bd2af327c5.png)

  ...but even tho it was best solution for this case I think final result isn't as strong as simpler "non-problem" examples (oof, gif compression):

  ![c43ebd38-d1e3-11e6-864f-c8df84e55d6a](https://cloud.githubusercontent.com/assets/1779444/21659522/2befa9b4-d299-11e6-9c60-b7838135122f.gif)

  Let me know what u think tho.
